### PR TITLE
Add swap alias option

### DIFF
--- a/lib/embulk/output/elasticsearch_using_url.rb
+++ b/lib/embulk/output/elasticsearch_using_url.rb
@@ -24,6 +24,7 @@ module Embulk
           "retry_on_failure" => config.param("retry_on_failure", :integer, default: 5),
           "before_template_name" => config.param("before_template_name", :string, default: nil),
           "before_template" => config.param("before_template", :hash, default: nil),
+          "swap_alias" => config.param("swap_alias", :bool, default: false),
         }
         task['time_value'] = Time.now.strftime('%Y.%m.%d.%H.%M.%S')
         task['index'] = Time.now.strftime(task['index'])
@@ -47,8 +48,13 @@ module Embulk
       def self.cleanup(task, schema, count, task_reports)
         if task['mode'] == 'replace'
           client = create_client(task)
-          create_aliases(client, task['index'], get_index(task))
-          delete_aliases(client, task)
+          if task['swap_alias']
+            swap_aliases(client, task['index'], get_index(task))
+            delete_aliases(client, task)
+          else
+            create_aliases(client, task['index'], get_index(task))
+            delete_aliases(client, task)
+          end
         end
       end
 
@@ -82,6 +88,28 @@ module Embulk
             end
           end
         }
+      end
+
+      def self.swap_aliases(client, als, index)
+        actions = []
+
+        actions.push({ add: { index: index, alias: als } })
+        Embulk.logger.info "added swap target: add, #{als}, index: #{index}"
+
+        indices = client.indices.get_aliases.select { |key, value| value['aliases'].include? task['index'] }.keys
+        indices = indices.select { |index| /^#{get_index_prefix(task)}-(\d*)/ =~ index }
+        indices.each { |index|
+          if index != get_index(task)
+            actions.push({ remove: { index: index, alias: als } })
+            Embulk.logger.info "added swap target: remove, #{als}, index: #{index}"
+          end
+        }
+
+        client.indices.update_aliases body: {
+          actions: actions
+        }
+
+        Embulk.logger.info "swapped alias: #{als}"
       end
 
       def self.get_index(task)

--- a/lib/embulk/output/elasticsearch_using_url.rb
+++ b/lib/embulk/output/elasticsearch_using_url.rb
@@ -95,7 +95,7 @@ module Embulk
         actions = []
 
         actions.push({ add: { index: get_index(task), alias: als } })
-        Embulk.logger.info "added swap target: add, #{als}, index: #{get_index(task)}"
+        Embulk.logger.info "register alias swap action: add, alias: #{als}, index: #{get_index(task)}"
 
         indices = client.indices.get_aliases.select { |key, value| value['aliases'].include? als }.keys
         indices = indices.select { |index| /^#{get_index_prefix(task)}-(\d*)/ =~ index }
@@ -104,7 +104,7 @@ module Embulk
           if index != get_index(task)
             actions.push({ remove: { index: index, alias: als } })
             indices_deleted_alias.push(index)
-            Embulk.logger.info "added swap target: remove, #{als}, index: #{index}"
+            Embulk.logger.info "register alias swap action: remove, alias: #{als}, index: #{index}"
           end
         }
 


### PR DESCRIPTION
`mode: replace` によるインデックスの洗い替えを行う際、以下の処理を同時ではなく順に行っている。

1. エイリアスに新しいインデックスを追加
1. エイリアスから古いインデックスを削除

そのため、1 と 2 の間のわずかな期間に新旧のデータが重複してしまう。

そこで 1 と 2 を同時に行う `swap_alias` オプションを追加した。
（ swap_alias=true で有効）

### swap_alias=false
```
...
2017-12-12 10:31:48.522 +0900 [INFO] (0001:transaction): created alias: test_index, index: test_index-test_type-2017.12.12.10.31.42
2017-12-12 10:31:48.968 +0900 [INFO] (0001:transaction): deleted alias: test_index, index: test_index-test_type-2017.12.12.10.09.27
...
```

### swap_alias=true
```
...
2017-12-12 10:32:39.718 +0900 [INFO] (0001:transaction): register alias swap action: add, alias: test_index, index: test_index-test_type-2017.12.12.10.32.34
2017-12-12 10:32:39.965 +0900 [INFO] (0001:transaction): register alias swap action: remove, alias: test_index, index: test_index-test_type-2017.12.12.10.31.42
2017-12-12 10:32:40.213 +0900 [INFO] (0001:transaction): swapped alias: test_index
...
```
